### PR TITLE
Update secret-scanning.yml

### DIFF
--- a/data/secret-scanning.yml
+++ b/data/secret-scanning.yml
@@ -1,4 +1,4 @@
-- provider: 'Adafruit latest'
+- provider: 'Adafruit and another commit'
   supportedSecret: 'Adafruit IO Key'
   secretType: 'adafruit_io_key'
   versions:

--- a/data/secret-scanning.yml
+++ b/data/secret-scanning.yml
@@ -1,4 +1,4 @@
-- provider: 'Adafruit IO'
+- provider: 'Adafruit latest'
   supportedSecret: 'Adafruit IO Key'
   secretType: 'adafruit_io_key'
   versions:


### PR DESCRIPTION
Testing the 

```
  pull_request_target:
    types:
      - opened
```

bit in
```
name: Secret Scanning Pattern Table Updates

# **What it does**: When a PR that updates `data/secret-scanning.yml` is opened in docs-internal, it adds the `ready-for-docs-review` label, as well as a comment explaining what this PR is for and that it needs to be reviewed quickly. It also provides reviewing instructions, and gives details of who can help.
# **Why we have it**: To help Docs Content team members know what to do with this sort of PRs, or to direct them to who can help if they don't feel comfortable reviewing the PR themselves.
# **Who does it impact**: docs-internal maintainers and docs content first responders.

on:
  pull_request:
    paths:
      - data/secret-scanning.yml
  pull_request_target:
    types:
      - opened
permissions:
  pull-requests: write
  repository-projects: write
jobs:
  Process-secret-scanning-PR:
    runs-on: ubuntu-latest
    steps:
      - name: Label pull requests updating the secret-scanning.yml file with ready-for-doc-review
        run: gh pr edit $PR --add-label "ready-for-doc-review"
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          PR: ${{ github.event.pull_request.html_url }}
      - name: Comment on the secret scanning partners PR
        run: >
          gh pr comment $PR --body "This PR updates data for secret scanning patterns
          in the _/data/secret-scanning.yml_ file. The data in this file is used
          to populate the tables in the '[Secret scanning
          patterns](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-patterns#supported-secrets)' article at build time.
            
          - The secret scanning team updates this file fairly regularly, and raises PRs in the `docs-internal` repository to update our docs accordingly. We've agreed to review these PRs **quickly** as the changes are already effective when these PRs reach us.
            
          - Anyone in the Docs Content team can review and merge this PR. A few guidelines:
              - You can only merge this PR if it's had a technical review (see who's approved it in the 'Reviewers' section in the top right corner).
              - To test that the changes appear on Staging, look at the preview of the 'Secret scanning patterns' file. You may need to use the product picker to look at the table for different GitHub products, and test the versioning.
              - If you don't feel comfortable reviewing this PR, please post a link to it in the #code-security-docs Slack channel so someone from the Dependencies & Secrets focus team can take a look.  

          - For more information about this automation, and the reasons why we have decided to implement it, see [About automations for Dependencies & Secrets](https://github.com/github/docs-content/blob/main/focus-areas/code-security/about-automations-for-dependencies-and-secrets.md#secret-scanning-prs-adding-new-supported-patterns) in the 'docs-content' repository.

          - Thank you :fishsticks: :sparkling_heart:"
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          PR: ${{ github.event.pull_request.html_url }}

```
